### PR TITLE
Update ark_survival_ascended.psm1 to fix ServerAdminPassword

### DIFF
--- a/templates/ark_survival_ascended.psm1
+++ b/templates/ark_survival_ascended.psm1
@@ -193,13 +193,13 @@ $ArgumentList = @(
   "?listen",
   "?SessionName=`"$($Server.SessionName)`"",
   "?ServerPassword=`"$($Server.Password)`"",
-  "?ServerAdminPassword=`"$($Server.ManagementPassword)`"",
   "?Port=$($Server.Port)",
   "?QueryPort=$($Server.QueryPort)",
   "?RCONEnabled=$($Server.EnableRcon)",
   "?RCONPort=$($Server.ManagementPort)",
   "?ServerPVE=$($Server.ServerPVE)",
-  "?MaxPlayers=$($Server.MaxPlayers)"
+  "?MaxPlayers=$($Server.MaxPlayers)",
+  "?ServerAdminPassword=`"$($Server.ManagementPassword)`""
 )
 
 if ($Server.BattlEye -eq "False") {


### PR DESCRIPTION
Moved ?ServerAdminPassword to the end, to fix the error of incorrectly writing the admin password to GameSetting.ini