### PR TITLE
Fix reboot loop: Update comparison date method

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,4 @@
 {
   "powershell.scriptAnalysis.settingsPath": ".vscode\\PSScriptAnalyzerSettings.psd1",
   "powershell.scriptAnalysis.enable": true,
-  "files.exclude": {
-    "**/backups": true,
-    "**/logs": true,
-    "**/tools": true,
-    "**/servers": true
-  }
 }

--- a/functions/process/Get-Lock.psm1
+++ b/functions/process/Get-Lock.psm1
@@ -3,8 +3,12 @@ function Get-Lock {
   [OutputType([boolean])]
   param (
   )
+  if ($Global.Debug){
+    Write-ScriptMsg "Debug Mode, skipping Lock check..."
+    return $false
+  }
   if ((Test-Path -Path ".\servers\$($Server.Name).LOCK" -PathType "Leaf" -ErrorAction SilentlyContinue)) {
-    $TimeStamp = Get-IniValue -file ".\servers\$($Server.Name).LOCK" -category "Lock" -key "TimeStamp"
+    $TimeStamp = [datetime]::ParseExact((Get-IniValue -file ".\servers\$($Server.Name).LOCK" -category "Lock" -key "TimeStamp"), $Global.DateTimeFormat, $null)
     if ($TimeStamp -lt (Get-Date).AddMinutes(-$Global.LockTimeout)) {
       Write-ScriptMsg "Process Lock is too old, removing..."
       $null = Remove-Item -Path ".\servers\$($Server.Name).LOCK" -Force -ErrorAction SilentlyContinue

--- a/functions/process/Lock-Process.psm1
+++ b/functions/process/Lock-Process.psm1
@@ -5,7 +5,7 @@ function Lock-Process {
   )
   try {
     $null = New-Item -Path ".\servers\" -Name "$($Server.Name).LOCK" -ItemType "file" -Force -ErrorAction SilentlyContinue
-    Set-IniValue -file ".\servers\$($Server.Name).LOCK" -category "Lock" -key "TimeStamp" -value (Get-Date)
+    Set-IniValue -file ".\servers\$($Server.Name).LOCK" -category "Lock" -key "TimeStamp" -value ((Get-Date).ToString($Global.DateTimeFormat))
     Write-ScriptMsg "Locking Process."
   }
   catch {

--- a/functions/process/Register-PID.psm1
+++ b/functions/process/Register-PID.psm1
@@ -20,7 +20,7 @@ function Register-PID {
       # Try to find the correct process.
       # Get a process list of all the process name are equal to  $Server.ProcessName where the StartTime is higher than $Server.StartTime
       $CorrectProcess = Get-Process -Name $Server.ProcessName |
-      Where-Object -Property StartTime -gt -Value $Server.StartTime
+      Where-Object -Property StartTime -gt -Value ([datetime]::ParseExact($Server.StartTime, $Global.DateTimeFormat, $null))
       if ($CorrectProcess) {
         $ServerProcess = $CorrectProcess
         $WrongProcess = $false

--- a/functions/server/Request-Update.psm1
+++ b/functions/server/Request-Update.psm1
@@ -71,10 +71,13 @@ function Request-Update {
   Write-ServerMsg "Remote Build ID: $RemoteBuildID"
 
   #Delete the script and update return file.
-  $null = Remove-Item -Path $ScriptPath -Confirm:$false -ErrorAction SilentlyContinue
-  #$null = Rename-Item -Path $ScriptPath -NewName "$ScriptFile.$(Get-TimeStamp).txt" -ErrorAction SilentlyContinue
-  $null = Remove-Item -Path ".\servers\$UpdateReturnFile" -Confirm:$false -ErrorAction SilentlyContinue
-  #$null = Rename-Item -Path ".\servers\$UpdateReturnFile" -NewName "$UpdateReturnFile.$(Get-TimeStamp).txt" -ErrorAction SilentlyContinue
+  if ($Global.Debug){
+    $null = Rename-Item -Path $ScriptPath -NewName "$ScriptFile.$(Get-TimeStamp).txt" -ErrorAction SilentlyContinue
+    $null = Rename-Item -Path ".\servers\$UpdateReturnFile" -NewName "$UpdateReturnFile.$(Get-TimeStamp).txt" -ErrorAction SilentlyContinue
+  } else {
+    $null = Remove-Item -Path $ScriptPath -Confirm:$false -ErrorAction SilentlyContinue
+    $null = Remove-Item -Path ".\servers\$UpdateReturnFile" -Confirm:$false -ErrorAction SilentlyContinue
+  }
 
   #Return true if the server needs to be updated.
   if ($InstallState -match "Update Required") {

--- a/functions/server/Start-Server.psm1
+++ b/functions/server/Start-Server.psm1
@@ -4,7 +4,7 @@ function Start-Server {
     Start-ServerPrep
     Write-ScriptMsg "Starting Server..."
     #Create a Timestamp
-    $timestamp = Get-Date
+    $timestamp = Get-TimeStamp
     Add-Member -InputObject $Server -Name "StartTime" -Type NoteProperty -Value $timestamp
     if ($Server.Arguments.length -gt 0) {
       Write-ServerMsg "Starting Server $($Server.Launcher) with Arguments: $($Server.Arguments)"

--- a/functions/server/Update-Server.psm1
+++ b/functions/server/Update-Server.psm1
@@ -73,6 +73,8 @@ function Update-Server {
     Exit-WithError -ErrorMsg "SteamCMD failed to complete."
   }
   #Delete the script.
-  $null = Remove-Item -Path $ScriptPath -Confirm:$false -ErrorAction SilentlyContinue
+  if (-not $Global.Debug){
+    $null = Remove-Item -Path $ScriptPath -Confirm:$false -ErrorAction SilentlyContinue
+  }
 }
 Export-ModuleMember -Function Update-Server

--- a/functions/util/Get-TaskConfig.psm1
+++ b/functions/util/Get-TaskConfig.psm1
@@ -1,6 +1,6 @@
 function Get-TaskConfig {
   Write-ScriptMsg "Getting Tasks Schedule..."
-  $EmptyDate = (Get-Date).AddDay(-1).ToString($Global.DateTimeFormat)
+  $EmptyDate = (Get-Date).AddYears(-1).ToString($Global.DateTimeFormat)
   $NextAlive = Get-IniValue -file ".\servers\$($Server.Name).INI" -category "Schedule" -key "NextAlive"
   if([string]::IsNullOrEmpty($NextAlive)) {
     $NextAlive = $EmptyDate

--- a/functions/util/Get-TaskConfig.psm1
+++ b/functions/util/Get-TaskConfig.psm1
@@ -1,12 +1,18 @@
 function Get-TaskConfig {
   Write-ScriptMsg "Getting Tasks Schedule..."
-  $EmptyDate = (Get-Date).AddYear(-1).ToString($Global.DateTimeFormat)
+  $EmptyDate = (Get-Date).AddDay(-1).ToString($Global.DateTimeFormat)
   $NextAlive = Get-IniValue -file ".\servers\$($Server.Name).INI" -category "Schedule" -key "NextAlive"
-  if([string]::IsNullOrEmpty($NextAlive)) $NextAlive = $EmptyDate
+  if([string]::IsNullOrEmpty($NextAlive)) {
+    $NextAlive = $EmptyDate
+  }
   $NextUpdate = Get-IniValue -file ".\servers\$($Server.Name).INI" -category "Schedule" -key "NextUpdate"
-  if([string]::IsNullOrEmpty($NextUpdate)) $NextUpdate = $EmptyDate
+  if([string]::IsNullOrEmpty($NextUpdate)) {
+    $NextUpdate = $EmptyDate
+  }
   $NextRestart = Get-IniValue -file ".\servers\$($Server.Name).INI" -category "Schedule" -key "NextRestart"
-  if([string]::IsNullOrEmpty($NextRestart)) $NextRestart = $EmptyDate
+  if([string]::IsNullOrEmpty($NextRestart)) {
+    $NextRestart = $EmptyDate
+  }
   return [hashtable] @{
     NextAlive   = $NextAlive;
     NextUpdate  = $NextUpdate;

--- a/functions/util/Get-TaskConfig.psm1
+++ b/functions/util/Get-TaskConfig.psm1
@@ -1,18 +1,28 @@
 function Get-TaskConfig {
   Write-ScriptMsg "Getting Tasks Schedule..."
-  $EmptyDate = (Get-Date).AddYears(-1).ToString($Global.DateTimeFormat)
+  $OldDate = [datetime]::ParseExact("2000-01-01_00-00-00","yyyy-MM-dd_HH-mm-ss", $null)
+
   $NextAlive = Get-IniValue -file ".\servers\$($Server.Name).INI" -category "Schedule" -key "NextAlive"
   if([string]::IsNullOrEmpty($NextAlive)) {
-    $NextAlive = $EmptyDate
+    $NextAlive = $OldDate
+  } else {
+    $NextAlive = [datetime]::ParseExact($NextAlive, $Global.DateTimeFormat, $null)
   }
+
   $NextUpdate = Get-IniValue -file ".\servers\$($Server.Name).INI" -category "Schedule" -key "NextUpdate"
   if([string]::IsNullOrEmpty($NextUpdate)) {
-    $NextUpdate = $EmptyDate
+    $NextUpdate = $OldDate
+  } else {
+    $NextUpdate = [datetime]::ParseExact($NextUpdate, $Global.DateTimeFormat, $null)
   }
+
   $NextRestart = Get-IniValue -file ".\servers\$($Server.Name).INI" -category "Schedule" -key "NextRestart"
   if([string]::IsNullOrEmpty($NextRestart)) {
-    $NextRestart = $EmptyDate
+    $NextRestart = $OldDate
+  } else {
+    $NextRestart = [datetime]::ParseExact($NextRestart, $Global.DateTimeFormat, $null)
   }
+
   return [hashtable] @{
     NextAlive   = $NextAlive;
     NextUpdate  = $NextUpdate;

--- a/functions/util/Get-TaskConfig.psm1
+++ b/functions/util/Get-TaskConfig.psm1
@@ -1,8 +1,12 @@
 function Get-TaskConfig {
   Write-ScriptMsg "Getting Tasks Schedule..."
+  $EmptyDate = (Get-Date).AddYear(-1).ToString($Global.DateTimeFormat)
   $NextAlive = Get-IniValue -file ".\servers\$($Server.Name).INI" -category "Schedule" -key "NextAlive"
+  if([string]::IsNullOrEmpty($NextAlive)) $NextAlive = $EmptyDate
   $NextUpdate = Get-IniValue -file ".\servers\$($Server.Name).INI" -category "Schedule" -key "NextUpdate"
+  if([string]::IsNullOrEmpty($NextUpdate)) $NextUpdate = $EmptyDate
   $NextRestart = Get-IniValue -file ".\servers\$($Server.Name).INI" -category "Schedule" -key "NextRestart"
+  if([string]::IsNullOrEmpty($NextRestart)) $NextRestart = $EmptyDate
   return [hashtable] @{
     NextAlive   = $NextAlive;
     NextUpdate  = $NextUpdate;

--- a/functions/util/Get-TimeStamp.psm1
+++ b/functions/util/Get-TimeStamp.psm1
@@ -1,5 +1,5 @@
 Function Get-TimeStamp {
-  return Get-Date -Format "yyyy-MM-dd_HH-mm-ss"
+  return (Get-Date).ToString($Global.DateTimeFormat)
 }
 
 Export-ModuleMember -Function Get-TimeStamp

--- a/functions/util/Register-Task.psm1
+++ b/functions/util/Register-Task.psm1
@@ -1,13 +1,11 @@
 function Register-Task {
   $action = New-ScheduledTaskAction -Execute "Powershell.exe" -Argument "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -File $scriptpath -ServerCfg `"$ServerCfg`" -Task" -WorkingDirectory $dir
-  $trigger = New-ScheduledTaskTrigger -Daily -At 12am -RandomDelay (New-TimeSpan -Minutes $Global.TaskCheckFrequency)
+  $trigger = New-ScheduledTaskTrigger -Daily -At 12am -RandomDelay (New-TimeSpan -Minutes $Global.TaskCheckFrequency) -RepetitionInterval (New-TimeSpan -Minutes $Global.TaskCheckFrequency) -RepetitionDuration (New-TimeSpan -Hours 23 -Minutes 55)
   $settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Minutes 10)
   $description = "Run Tasks for $($server.Name)"
   $title = "Tasks-$($server.Name)"
   $task = New-ScheduledTask -Description $description -Action $action -Trigger $trigger -Settings $settings
   $RegisteredTask = Register-ScheduledTask $title -InputObject $task
-  $RegisteredTask.Triggers.Repetition.Duration = "P1D" #Repeat for a duration of one day
-  $RegisteredTask.Triggers.Repetition.Interval = "PT$($Global.TaskCheckFrequency)M" #Repeat every X minutes, use PT1H for every hour
   $null = Set-ScheduledTask $RegisteredTask
 }
 Export-ModuleMember -Function Register-Task

--- a/functions/util/Register-Task.psm1
+++ b/functions/util/Register-Task.psm1
@@ -1,11 +1,13 @@
 function Register-Task {
   $action = New-ScheduledTaskAction -Execute "Powershell.exe" -Argument "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -File $scriptpath -ServerCfg `"$ServerCfg`" -Task" -WorkingDirectory $dir
-  $trigger = New-ScheduledTaskTrigger -Daily -At 12am -RandomDelay (New-TimeSpan -Minutes $Global.TaskCheckFrequency) -RepetitionInterval (New-TimeSpan -Minutes $Global.TaskCheckFrequency) -RepetitionDuration (New-TimeSpan -Hours 23 -Minutes 55)
-  $settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Minutes 10)
+  $trigger = New-ScheduledTaskTrigger -Daily -At 12am
+  $settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Hours 3)
   $description = "Run Tasks for $($server.Name)"
   $title = "Tasks-$($server.Name)"
   $task = New-ScheduledTask -Description $description -Action $action -Trigger $trigger -Settings $settings
   $RegisteredTask = Register-ScheduledTask $title -InputObject $task
+  $RegisteredTask.Triggers.Repetition.Duration = "P1D" #Repeat for a duration of one day
+  $RegisteredTask.Triggers.Repetition.Interval = "PT$($Global.TaskCheckFrequency)M" #Repeat every X minutes, use PT1H for every hour
   $null = Set-ScheduledTask $RegisteredTask
 }
 Export-ModuleMember -Function Register-Task

--- a/functions/util/Update-TaskConfig.psm1
+++ b/functions/util/Update-TaskConfig.psm1
@@ -13,17 +13,17 @@ function Update-TaskConfig {
   Write-ScriptMsg "Updating Tasks Schedule..."
 
   if ($Alive) {
-    $NextAlive = (Get-Date).AddMinutes($Global.AliveCheckFrequency)
+    $NextAlive = (Get-Date).AddMinutes($Global.AliveCheckFrequency).ToString($Global.DateTimeFormat)
     Set-IniValue -file ".\servers\$($Server.Name).INI" -category "Schedule" -key "NextAlive" -value $NextAlive
   }
 
   if ($Update) {
-    $NextUpdate = (Get-Date).AddMinutes($Global.UpdateCheckFrequency)
+    $NextUpdate = (Get-Date).AddMinutes($Global.UpdateCheckFrequency).ToString($Global.DateTimeFormat)
     Set-IniValue -file ".\servers\$($Server.Name).INI" -category "Schedule" -key "NextUpdate" -value $NextUpdate
   }
 
   if ($Restart) {
-    $NextRestart = (Get-Date -Hour $Server.AutoRestartTime[0] -Minute $Server.AutoRestartTime[1] -Second  $Server.AutoRestartTime[2]).AddDays(1)
+    $NextRestart = (Get-Date -Hour $Server.AutoRestartTime[0] -Minute $Server.AutoRestartTime[1] -Second  $Server.AutoRestartTime[2]).AddDays(1).ToString($Global.DateTimeFormat)
     Set-IniValue -file ".\servers\$($Server.Name).INI" -category "Schedule" -key "NextRestart" -value $NextRestart
   }
 }

--- a/global.psm1
+++ b/global.psm1
@@ -41,17 +41,18 @@ $GlobalDetails = @{
   #Should be lower or equal to the two above
   TaskCheckFrequency   = 5
 
-  #Log run without actions
-  LogEmptyRun          = $false
-
   #Lock Timeout in miuntes
-  LockTimeout          = 30
+  LockTimeout          = 120
 
   #Max download retries
   MaxDownloadRetries   = 10
-    
-  # Define the DateTimeFormat 
-  DateTimeFormat       = "yyyy-MM-dd HH:mm:ss"
+
+  # Define the DateTimeFormat (Change at your own risk, used for filenames)
+  DateTimeFormat       = "yyyy-MM-dd_HH-mm-ss"
+
+  # Debug Mode (will not delete any logs or script files and will ignore script locks)
+  # !!! DO NOT ENABLE IN PRODUCTION !!!
+  Debug                = $false
 }
 
 #Create the object

--- a/global.psm1
+++ b/global.psm1
@@ -49,6 +49,9 @@ $GlobalDetails = @{
 
   #Max download retries
   MaxDownloadRetries   = 10
+    
+  # Define the DateTimeFormat 
+  DateTimeFormat       = "yyyy-MM-dd HH:mm:ss"
 }
 
 #Create the object

--- a/main.ps1
+++ b/main.ps1
@@ -112,7 +112,7 @@ if ($Task) {
     Unregister-Task
     Exit
   }
-  if (($Server.AutoRestartOnCrash) -and ((New-TimeSpan -Start (Get-Date) -End $TasksSchedule.NextAlive) -le 0)) {
+  if (($Server.AutoRestartOnCrash) -and ($TasksSchedule.NextAlive -le (Get-Date).ToString($Global.DateTimeFormat))) {
     Write-ScriptMsg "Checking Alive State"
     if (-not (Get-ServerProcess)) {
       Write-ScriptMsg "Server is Dead, Restarting..."
@@ -127,7 +127,7 @@ if ($Task) {
     Write-ScriptMsg "Too soon for Alive check"
   }
 
-  if (($Server.AutoUpdates) -and ((New-TimeSpan -Start (Get-Date) -End $TasksSchedule.NextUpdate) -le 0)) {
+  if (($Server.AutoUpdates) -and ($TasksSchedule.NextUpdate -le (Get-Date).ToString($Global.DateTimeFormat))) {
     Write-ScriptMsg "Checking on steamCMD if updates are avaiable for $($Server.Name)..."
     if (Request-Update) {
       Write-ScriptMsg "Updates are available for $($Server.Name), Proceeding with update process..."
@@ -142,7 +142,7 @@ if ($Task) {
     Write-ScriptMsg "Too soon for Update check"
   }
 
-  if (($Server.AutoRestart) -and ((New-TimeSpan -Start (Get-Date) -End $TasksSchedule.NextRestart) -le 0)) {
+  if (($Server.AutoRestart) -and ($TasksSchedule.NextRestart -le (Get-Date).ToString($Global.DateTimeFormat))) {
     Write-ScriptMsg "Server is due for Restart"
     $FullRunRequired = $true
     Update-TaskConfig -Restart

--- a/main.ps1
+++ b/main.ps1
@@ -112,7 +112,7 @@ if ($Task) {
     Unregister-Task
     Exit
   }
-  if (($Server.AutoRestartOnCrash) -and (($TasksSchedule.NextAlive) -le (Get-Date))) {
+  if (($Server.AutoRestartOnCrash) -and ((New-TimeSpan -Start Get-Date -End $TasksSchedule.NextAlive) -le 0)) {
     Write-ScriptMsg "Checking Alive State"
     if (-not (Get-ServerProcess)) {
       Write-ScriptMsg "Server is Dead, Restarting..."
@@ -127,7 +127,7 @@ if ($Task) {
     Write-ScriptMsg "Too soon for Alive check"
   }
 
-  if (($Server.AutoUpdates) -and (($TasksSchedule.NextUpdate) -le (Get-Date))) {
+  if (($Server.AutoUpdates) -and ((New-TimeSpan -Start Get-Date -End $TasksSchedule.NextUpdate) -le 0)) {
     Write-ScriptMsg "Checking on steamCMD if updates are avaiable for $($Server.Name)..."
     if (Request-Update) {
       Write-ScriptMsg "Updates are available for $($Server.Name), Proceeding with update process..."
@@ -142,7 +142,7 @@ if ($Task) {
     Write-ScriptMsg "Too soon for Update check"
   }
 
-  if (($Server.AutoRestart) -and (($TasksSchedule.NextRestart) -le (Get-Date))) {
+  if (($Server.AutoRestart) -and ((New-TimeSpan -Start Get-Date -End $TasksSchedule.NextRestart) -le 0)) {
     Write-ScriptMsg "Server is due for Restart"
     $FullRunRequired = $true
     Update-TaskConfig -Restart

--- a/main.ps1
+++ b/main.ps1
@@ -112,7 +112,7 @@ if ($Task) {
     Unregister-Task
     Exit
   }
-  if (($Server.AutoRestartOnCrash) -and ((New-TimeSpan -Start Get-Date -End $TasksSchedule.NextAlive) -le 0)) {
+  if (($Server.AutoRestartOnCrash) -and ((New-TimeSpan -Start (Get-Date) -End $TasksSchedule.NextAlive) -le 0)) {
     Write-ScriptMsg "Checking Alive State"
     if (-not (Get-ServerProcess)) {
       Write-ScriptMsg "Server is Dead, Restarting..."
@@ -127,7 +127,7 @@ if ($Task) {
     Write-ScriptMsg "Too soon for Alive check"
   }
 
-  if (($Server.AutoUpdates) -and ((New-TimeSpan -Start Get-Date -End $TasksSchedule.NextUpdate) -le 0)) {
+  if (($Server.AutoUpdates) -and ((New-TimeSpan -Start (Get-Date) -End $TasksSchedule.NextUpdate) -le 0)) {
     Write-ScriptMsg "Checking on steamCMD if updates are avaiable for $($Server.Name)..."
     if (Request-Update) {
       Write-ScriptMsg "Updates are available for $($Server.Name), Proceeding with update process..."
@@ -142,7 +142,7 @@ if ($Task) {
     Write-ScriptMsg "Too soon for Update check"
   }
 
-  if (($Server.AutoRestart) -and ((New-TimeSpan -Start Get-Date -End $TasksSchedule.NextRestart) -le 0)) {
+  if (($Server.AutoRestart) -and ((New-TimeSpan -Start (Get-Date) -End $TasksSchedule.NextRestart) -le 0)) {
     Write-ScriptMsg "Server is due for Restart"
     $FullRunRequired = $true
     Update-TaskConfig -Restart


### PR DESCRIPTION
The problem arose from the fact that the date of the next update was compared with the current date 01/01/2024 is less than 12/31/2023 (compared values) and therefore launches a full update.