### PR TITLE
fixing issue with 'next' times

### DIFF
--- a/main.ps1
+++ b/main.ps1
@@ -127,7 +127,7 @@ if ($Task) {
   }
 
   if ($Server.AutoRestartOnCrash) {
-    if (($TasksSchedule.NextAlive) -le (Get-Date)) {
+    if ((($TasksSchedule.NextAlive) -le (Get-Date)) -or ($Global.AliveCheckFrequency -le $Global.TaskCheckFrequency)) {
       Write-ScriptMsg "Checking Alive State"
       if (-not (Get-ServerProcess)) {
         Write-ScriptMsg "Server is Dead, Restarting..."
@@ -147,7 +147,7 @@ if ($Task) {
   }
 
   if ($Server.AutoUpdates) {
-    if (($TasksSchedule.NextUpdate) -le (Get-Date)) {
+    if ((($TasksSchedule.NextUpdate) -le (Get-Date)) -or ($Global.UpdateCheckFrequency -le $Global.TaskCheckFrequency)) {
       Write-ScriptMsg "Checking on steamCMD if updates are available for $($Server.Name)..."
       if (Request-Update) {
         Write-ScriptMsg "Updates are available for $($Server.Name), Proceeding with update process..."


### PR DESCRIPTION
There was a issue where if you set the AliveCheckFrequency or UpdateCheckFrequency to the same as TaskCheckFrequency, you would expect it to do then every time the task is run but that wasn't happening due to duration of those actions affecting the next check

handle less than and equals to