### PR TITLE
7Zip4PowerShell and backup filesize/duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ By [@BananaAcid](https://github.com/BananaAcid/)
 - [Java JDK](https://aws.amazon.com/corretto/?filtered-posts.sort-by=item.additionalFields.createdDate&filtered-posts.sort-order=desc)
 - [Microsoft XNA Redistributable](https://www.microsoft.com/en-ca/download/details.aspx?id=20914)
 
+# Optional Additional Packages
+
+- [7Zip4PowerShell](https://www.powershellgallery.com/packages/7Zip4Powershell/)
+
+```ps
+Install-Module -Name 7Zip4Powershell
+```
+
 # Expanding the Code
 
 You can create pull requests for changes to this project.

--- a/functions/server/Backup-Server.psm1
+++ b/functions/server/Backup-Server.psm1
@@ -2,6 +2,7 @@ function Backup-Server {
   Write-ServerMsg "Creating Backup."
   #Create backup name from date and time
   $BackupName = Get-TimeStamp
+  $BackupStart = Get-Date
 
   #Check if it's friday (Sunday is 0)
   if ((Get-Date -UFormat %u) -eq 5) {
@@ -89,7 +90,11 @@ try {
   }
 
   # Compress the temporary directory into a zip archive using the specified compression options
-  Compress-Archive -Path $TempDirectory -DestinationPath "$($Backups.Path)\$Type\$BackupName.zip" -CompressionLevel 'Fastest'
+  if (Get-Module -ListAvailable -Name 7Zip4PowerShell) {
+    Compress-7Zip -Path $TempDirectory -ArchiveFileName "$($Backups.Path)\$Type\$BackupName.zip" -CompressionLevel 'Fast' -Format Zip
+  } else {
+    Compress-Archive -Path $TempDirectory -DestinationPath "$($Backups.Path)\$Type\$BackupName.zip" -CompressionLevel 'Fastest'
+  }
 
   # Remove the temporary directory
   Remove-Item -Path $TempDirectory -Force -Recurse
@@ -98,7 +103,7 @@ catch {
   Exit-WithError -ErrorMsg "Unable to backup server."
 }
 
-  Write-ServerMsg "Backup Created : $BackupName.zip"
+  Write-ServerMsg "Backup Created : $BackupName.zip [$((New-TimeSpan -Start $BackupStart).toString("g"))]"
 
   #Delete old backups
   Write-ServerMsg "Deleting old backups."

--- a/functions/server/Backup-Server.psm1
+++ b/functions/server/Backup-Server.psm1
@@ -103,7 +103,8 @@ catch {
   Exit-WithError -ErrorMsg "Unable to backup server."
 }
 
-  Write-ServerMsg "Backup Created : $BackupName.zip [$((New-TimeSpan -Start $BackupStart).toString("g"))]"
+  $zipFile = Get-Item "$($Backups.Path)\$Type\$BackupName.zip"
+  Write-ServerMsg "Backup Created : $BackupName.zip [$(Format-FileSize $zipFile.Length)][$((New-TimeSpan -Start $BackupStart).toString("g"))]"
 
   #Delete old backups
   Write-ServerMsg "Deleting old backups."

--- a/functions/util/Format-FileSize.psm1
+++ b/functions/util/Format-FileSize.psm1
@@ -1,0 +1,12 @@
+function Format-FileSize {
+    param([long]$size)
+    if ($size -gt 1GB) {
+        "{0:N2} GB" -f ($size / 1GB)
+    } elseif ($size -gt 1MB) {
+        "{0:N2} MB" -f ($size / 1MB)
+    } elseif ($size -gt 1KB) {
+        "{0:N2} KB" -f ($size / 1KB)
+    } else {
+        "$size bytes"
+    }
+}


### PR DESCRIPTION
7Zip4PowerShell is a much faster way to compress the backups, this setup allows that if the machine has it installed it'll use it. It sped up my ProjectZomboid backups from taking 12 minutes to taking 3 minutes (most of the remaining time was spent copying the files)