### PR TITLE
Terraria - Set Latest Version

### DIFF
--- a/templates/terraria.psm1
+++ b/templates/terraria.psm1
@@ -62,7 +62,7 @@ $ServerDetails = @{
   ConfigFolder       = ".\servers\$Name"
 
   #Server Version
-  Version            = "1423"
+  Version            = "1449"
 
   #Steam Server App Id *0 Skip SteamCMD Installation
   AppID              = 0


### PR DESCRIPTION
Version 1.4.4.9 released ~2 years ago; default template should include latest game version.