### PR TITLE
Update Register-Task.psm1

### DIFF
--- a/functions/util/Register-Task.psm1
+++ b/functions/util/Register-Task.psm1
@@ -1,5 +1,5 @@
 function Register-Task {
-  $action = New-ScheduledTaskAction -Execute "Powershell.exe" -Argument "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -File $scriptpath -ServerCfg `"$ServerCfg`" -Task" -WorkingDirectory $dir
+  $action = New-ScheduledTaskAction -Execute "Powershell.exe" -Argument "-WindowStyle Hidden -NoProfile -ExecutionPolicy Bypass -File `"$scriptpath`" -ServerCfg `"$ServerCfg`" -Task" -WorkingDirectory $dir
   $trigger = New-ScheduledTaskTrigger -Daily -At 12am
   $settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit (New-TimeSpan -Hours 3)
   $description = "Run Tasks for $($server.Name)"


### PR DESCRIPTION
Fix for Task Scheduler Error 0xFFFD0000

<img width="1399" height="255" alt="Screenshot" src="https://github.com/user-attachments/assets/418a5be2-eb0a-47a8-83ca-686f10f6c3d0" />

I found an error in Windows Server 2025 Task Scheduler. The error was gone when I added quotes in the action parameters.
Please note that I only edited an already created task; I have not tested new ones.